### PR TITLE
Feature: added comment argument to stage_datapoint and commit_datapoints

### DIFF
--- a/pyminder/goal.py
+++ b/pyminder/goal.py
@@ -31,15 +31,16 @@ class Goal:
         self._sparse_path = self._build_sparse_path()
         self._dense_path = self._build_dense_path()
 
-    def stage_datapoint(self, value, time):
+    def stage_datapoint(self, value, time, comment):
         self._staged_datapoints.append({
             "timestamp": time,
-            "value": value
+            "value": value,
+            "comment": comment
         })
 
     def commit_datapoints(self):
         for point in self.get_staged_datapoints():
-            self._beeminder.create_datapoint(self.slug, point['value'], point['timestamp'])
+            self._beeminder.create_datapoint(self.slug, point['value'], point['timestamp'], point['comment'])
 
         self._clear_cache()
 


### PR DESCRIPTION
Hi there,

I wanted to create this pull request with a very small set of changes to the behaviour of `Goal.stage_datapoint` and `Goal.commit_datapoints`. I am building a GitHub Action that uses this library to push datapoints to Beeminder's API, but I was noticing that `pyminder` wasn't passing comments through these two functions, although [`Beeminder.create_datapoint`](https://github.com/HaydenMacDonald/pyminder/blob/025caf1a592a0a69da8ff3e46ec969a5fb10f41a/pyminder/beeminder.py#L67) accepts a comment argument.

I have added comment as an argument to these functions and I believe these changes do not break any other functionality in the package. Let me know what you think of these changes and I'll be happy to alter the pull requests if I've overlooked anything.

Cheers! 