### PR TITLE
Type hints and default values for Beeminder.create_datapoint and Goal.stage_datapoint

### DIFF
--- a/pyminder/beeminder.py
+++ b/pyminder/beeminder.py
@@ -63,7 +63,7 @@ class Beeminder:
             self,
             goal_name: str,
             value: float,
-            unix_timestamp: float,
+            unix_timestamp: float = None,
             comment: str = None
     ):
         return self._call(f'/users/{self._user}/goals/{goal_name}/datapoints.json', data={

--- a/pyminder/goal.py
+++ b/pyminder/goal.py
@@ -31,7 +31,12 @@ class Goal:
         self._sparse_path = self._build_sparse_path()
         self._dense_path = self._build_dense_path()
 
-    def stage_datapoint(self, value, time, comment):
+    def stage_datapoint(
+            self,
+            value: float,
+            time: float = None,
+            comment: str = None
+    ):
         self._staged_datapoints.append({
             "timestamp": time,
             "value": value,


### PR DESCRIPTION
Hi again @narthur!

I've added a couple of type hints and default values for Beeminder.create_datapoint and Goal.stage_datapoint to keep the datapoint functionality in line with the [API's required values](https://api.beeminder.com/#postdata). Let me know what you think of these changes and if acceptable, would you be able to push the changes to PyPI?

Cheers!