### PR TITLE
Add Repr for Goal

### DIFF
--- a/pyminder/goal.py
+++ b/pyminder/goal.py
@@ -14,6 +14,17 @@ class Goal:
     _dense_path = None
     _day = 60 * 60 * 24
 
+    def __repr__(self):
+        return f"<Goal: {self.slug}-- {self.title} (Unit: {self.gunits}-- {self.safesum})>"
+
+    def __str__(self):
+        return (
+            f"{self.slug}\n"
+            f" {self.title}\n"
+            f" {self.safesum}\n"
+            f" {self.gunits}\n"
+        )
+
     def __init__(self, beeminder: Beeminder, python: Python, data: dict):
         self._beeminder = beeminder
         self._python = python


### PR DESCRIPTION
Hey, I just used pyminder in a small project I made: https://github.com/fergusFettes/beetimer

Here is one of the things that I thought of when trying it. But maybe there is a reason you didn't have this.

Just makes it much easier to see the goals. Here is what it looks like now. (Before it just told you the class name.)

```
In [3]: goals = pyminder.get_goals()

In [4]: goals[0]
Out[4]: <Goal: cartwheels-- six cartwheels or other flips per day (Unit: cartwheel-- safe for 2 days)>

In [5]: print(goals[0])
cartwheels
 six cartwheels or other flips per day
 safe for 2 days
 cartwheel
```